### PR TITLE
Add input argument for saving predictions in Kaggle submission format

### DIFF
--- a/benchmarks/ddxplus.py
+++ b/benchmarks/ddxplus.py
@@ -1,4 +1,6 @@
 import re
+import pandas as pd
+import os
 import evaluate
 from datasets import Dataset
 from colorama import Fore, Style
@@ -102,6 +104,17 @@ class MedicalDiagnosisBench(Bench):
             label_int = self.TEXT2LABEL[label.lower()]
             label_str = label
         return f"{label_int}. {label_str}"
+
+    def save_output(self, output_path):
+        df = pd.DataFrame({
+            "id": [i for i in range(len(self.predictions))],
+            "result": self.predictions
+        })
+
+        # Ensure the parent directory exists
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+        df.to_csv(output_path, index=False)
 
 def create_ddxplus():
     class DDXPlusBench(MedicalDiagnosisBench):

--- a/examples/self_streamicl.py
+++ b/examples/self_streamicl.py
@@ -312,6 +312,7 @@ if __name__ == "__main__":
     parser.add_argument('--device', type=str, default="cuda:0")
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--use_8bit', action='store_true')
+    parser.add_argument('--output_path', type=str, default=None, help='path to save csv file for kaggle submission')
     args = parser.parse_args()
 
     if args.bench_name.startswith("classification"):
@@ -324,7 +325,8 @@ if __name__ == "__main__":
         raise ValueError(f"Invalid benchmark name: {args.bench_name}")
     # Classification: Medical diagnosis; SQL generation: Text-to-SQL
     bench_cfg = {
-        'bench_name': args.bench_name
+        'bench_name': args.bench_name,
+        'output_path': args.output_path
     }
     llm_config = {
         'model_name': args.model_name,

--- a/examples/zeroshot.py
+++ b/examples/zeroshot.py
@@ -209,6 +209,7 @@ if __name__ == "__main__":
     parser.add_argument('--device', type=str, default="cuda:0")
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--use_8bit', action='store_true')
+    parser.add_argument('--output_path', type=str, default=None, help='path to save csv file for kaggle submission')
     args = parser.parse_args()
 
     if args.bench_name.startswith("classification"):
@@ -221,7 +222,8 @@ if __name__ == "__main__":
         raise ValueError(f"Invalid benchmark name: {args.bench_name}")
     # Classification: Medical diagnosis; SQL generation: Text-to-SQL
     bench_cfg = {
-        'bench_name': args.bench_name
+        'bench_name': args.bench_name,
+        'output_path': args.output_path
     }
     llm_config = {
         'model_name': args.model_name,

--- a/execution_pipeline.py
+++ b/execution_pipeline.py
@@ -48,6 +48,11 @@ def main(agent, bench_cfg, debug: bool = False, debug_samples: int = 10):
 
     metrics = bench.get_metrics()
     print(metrics)
+
+    output_path = bench_cfg.get("output_path", None)
+    if output_path is not None:
+        bench.save_output(output_path)
+
     return metrics
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ accelerate
 bitsandbytes
 protobuf
 sentencepiece
+pandas


### PR DESCRIPTION
Hello, I'm the TA for the Applied Deep Learning (ADL) course, where we plan to use Kaggle as the leaderboard platform. To help students submit in the correct format, this pull request adds an input argument that allows them to specify an output path for saving predictions in the required submission format.

### Changes:

- **Medical Diagnosis Task**: This update enables students to save their predicted labels as a CSV file formatted for Kaggle submission.
  
- **Text-to-SQL Task**: For this task, accuracy is evaluated based on whether the result sets retrieved by the model-generated SQL code exactly match those retrieved by the ground truth SQL command. To facilitate comparison on Kaggle, each result list from the predicted SQL output is hashed (using MD5) as implemented in `benchmarks/text_to_sql.py`. This allows for direct comparison of hashed values against the ground truth on Kaggle.

Please let me know if you have any suggestions for improvements or if there’s a more effective approach to achieve this functionality.